### PR TITLE
Fixed ContactDetails.jsx

### DIFF
--- a/src/js/views/ContactDetails.jsx
+++ b/src/js/views/ContactDetails.jsx
@@ -155,7 +155,7 @@ export const ContactDetails = () => {
                 </Card>
                 <div className="d-flex justify-content-between">
                     <Link to="/contact"><Button variant="danger">Volver</Button></Link>
-                    {params.mode == 'edit' || params.mode == 'add' && <Button type="submit" variant="success">Guardar cambios</Button>}
+                    {(params.mode == 'edit' || params.mode == 'add') && <Button type="submit" variant="success">Guardar cambios</Button>}
                 </div>
             </Form>
         </Container>


### PR DESCRIPTION
Fix #6 proposed by @ElisaGDR

> Al intentar guardar un contacto editado, aunque la lógica del back es correcta, no se muestra el botón `Guardar cambios` y no se puede realizar la acción. Poniendo paréntesis a `(params.mode == 'edit' || params.mode == 'add')` y luego siguiendo la lógica tal como estaba, ya se muestra el botón y hace su función. Así prioriza que una de estas dos condiciones se cumpla para seguir leyendo el código de la derecha.